### PR TITLE
Feat/web search package

### DIFF
--- a/cmd/web_search/main.go
+++ b/cmd/web_search/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/macedo/web_search/internal/web_search"
+)
+
+func main() {
+	engine := flag.String("engine", "google", "select search engine (options: google/duckduckgo/stackoverflow/github)")
+	flag.Parse()
+
+	text := strings.Join(flag.Args(), " ")
+
+	if err := run(*engine, text); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(engine string, text string) error {
+	searchEngine, err := getSearchEngine(engine)
+	if err != nil {
+		return err
+	}
+
+	searchEngine.SetQuery(text)
+
+	s := web_search.New(searchEngine)
+	return s.Exec()
+}
+
+func getSearchEngine(engine string) (web_search.Engine, error) {
+	switch engine {
+
+	case "google":
+		return web_search.NewGoogleEngine(), nil
+
+	case "duckduckgo", "ddg":
+		return web_search.NewDuckDuckGoEngine(), nil
+
+	case "github":
+		return web_search.NewGithubEngine(), nil
+
+	case "stackoverflow":
+		return web_search.NewStackOverflowEngine(), nil
+
+	default:
+		return nil, fmt.Errorf("search engine %q not supported", engine)
+	}
+}

--- a/cmd/web_search/main_test.go
+++ b/cmd/web_search/main_test.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestGetSearchEngine(t *testing.T) {
+	testCases := []struct {
+		Engine    string
+		Expected  string
+		ExpectErr bool
+		Name      string
+	}{
+		{
+			Engine:    "google",
+			Expected:  "https://google.com/search",
+			ExpectErr: false,
+			Name:      "google engine",
+		},
+		{
+			Engine:    "duckduckgo",
+			Expected:  "https://duckduckgo.com",
+			ExpectErr: false,
+			Name:      "duckduckgo engine",
+		},
+		{
+			Engine:    "ddg",
+			Expected:  "https://duckduckgo.com",
+			ExpectErr: false,
+			Name:      "ddg engine",
+		},
+		{
+			Engine:    "stackoverflow",
+			Expected:  "https://stackoverflow.com/search",
+			ExpectErr: false,
+			Name:      "stackoverflow engine",
+		},
+		{
+			Engine:    "github",
+			Expected:  "https://github.com/search",
+			ExpectErr: false,
+			Name:      "github engine",
+		},
+		{
+			Engine:    "bing",
+			Expected:  "",
+			ExpectErr: true,
+			Name:      "bing engine",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.Name, func(t *testing.T) {
+			e, err := getSearchEngine(tc.Engine)
+
+			if tc.ExpectErr {
+				if err == nil {
+					t.Errorf("expected error, got nil instead")
+				}
+
+				return
+			}
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if tc.Expected != e.URL() {
+				t.Errorf("Expected %q, got %q instead", tc.Expected, e.URL())
+			}
+		})
+	}
+}

--- a/internal/web_search/duckduckgo.go
+++ b/internal/web_search/duckduckgo.go
@@ -1,0 +1,18 @@
+package web_search
+
+import "net/url"
+
+type duckduckgo struct {
+	engine
+}
+
+func NewDuckDuckGoEngine() Engine {
+	return &duckduckgo{
+		engine: engine{
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "duckduckgo.com",
+			},
+		},
+	}
+}

--- a/internal/web_search/engine.go
+++ b/internal/web_search/engine.go
@@ -1,0 +1,25 @@
+package web_search
+
+import (
+	"net/url"
+)
+
+type Engine interface {
+	SetQuery(string)
+	URL() string
+}
+
+type engine struct {
+	url *url.URL
+}
+
+func (e *engine) SetQuery(query string) {
+	q := e.url.Query()
+	q.Set("q", query)
+
+	e.url.RawQuery = q.Encode()
+}
+
+func (e *engine) URL() string {
+	return e.url.String()
+}

--- a/internal/web_search/engine_test.go
+++ b/internal/web_search/engine_test.go
@@ -12,3 +12,14 @@ func TestGoogleEngineURL(t *testing.T) {
 		t.Errorf("expected URL %q, got %q instead", expectedURL, e.URL())
 	}
 }
+
+func TestDuckDuckGoEngineURL(t *testing.T) {
+	e := NewDuckDuckGoEngine()
+	e.SetQuery("golang")
+
+	expectedURL := "https://duckduckgo.com?q=golang"
+
+	if e.URL() != expectedURL {
+		t.Errorf("expected URL %q, got %q instead", expectedURL, e.URL())
+	}
+}

--- a/internal/web_search/engine_test.go
+++ b/internal/web_search/engine_test.go
@@ -1,0 +1,14 @@
+package web_search
+
+import "testing"
+
+func TestGoogleEngineURL(t *testing.T) {
+	e := NewGoogleEngine()
+	e.SetQuery("golang")
+
+	expectedURL := "https://google.com/search?q=golang"
+
+	if e.URL() != expectedURL {
+		t.Errorf("expected URL %q, got %q instead", expectedURL, e.URL())
+	}
+}

--- a/internal/web_search/engine_test.go
+++ b/internal/web_search/engine_test.go
@@ -23,3 +23,14 @@ func TestDuckDuckGoEngineURL(t *testing.T) {
 		t.Errorf("expected URL %q, got %q instead", expectedURL, e.URL())
 	}
 }
+
+func TestStackOverflowEngineURL(t *testing.T) {
+	e := NewStackOverflowEngine()
+	e.SetQuery("golang")
+
+	expectedURL := "https://stackoverflow.com/search?q=golang"
+
+	if e.URL() != expectedURL {
+		t.Errorf("expected URL %q, got %q instead", expectedURL, e.URL())
+	}
+}

--- a/internal/web_search/engine_test.go
+++ b/internal/web_search/engine_test.go
@@ -34,3 +34,14 @@ func TestStackOverflowEngineURL(t *testing.T) {
 		t.Errorf("expected URL %q, got %q instead", expectedURL, e.URL())
 	}
 }
+
+func TestGithubEngineURL(t *testing.T) {
+	e := NewGithubEngine()
+	e.SetQuery("golang")
+
+	expectedURL := "https://github.com/search?q=golang"
+
+	if e.URL() != expectedURL {
+		t.Errorf("expected URL %q, got %q instead", expectedURL, e.URL())
+	}
+}

--- a/internal/web_search/github.go
+++ b/internal/web_search/github.go
@@ -1,0 +1,19 @@
+package web_search
+
+import "net/url"
+
+type github struct {
+	engine
+}
+
+func NewGithubEngine() Engine {
+	return &github{
+		engine: engine{
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "github.com",
+				Path:   "search",
+			},
+		},
+	}
+}

--- a/internal/web_search/google.go
+++ b/internal/web_search/google.go
@@ -1,0 +1,19 @@
+package web_search
+
+import "net/url"
+
+type google struct {
+	engine
+}
+
+func NewGoogleEngine() Engine {
+	return &google{
+		engine: engine{
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "google.com",
+				Path:   "search",
+			},
+		},
+	}
+}

--- a/internal/web_search/search.go
+++ b/internal/web_search/search.go
@@ -1,0 +1,11 @@
+package web_search
+
+type Search struct {
+	engine Engine
+}
+
+func New(engine Engine) *Search {
+	return &Search{
+		engine: engine,
+	}
+}

--- a/internal/web_search/search_darwin.go
+++ b/internal/web_search/search_darwin.go
@@ -1,0 +1,11 @@
+package web_search
+
+import (
+	"os/exec"
+)
+
+var command = exec.Command
+
+func (s *Search) Exec() error {
+	return command("open", s.engine.URL()).Run()
+}

--- a/internal/web_search/search_darwin_test.go
+++ b/internal/web_search/search_darwin_test.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package web_search
+
+import (
+	"testing"
+)
+
+func TestExecDarwin(t *testing.T) {
+	e := NewGoogleEngine()
+	s := New(e)
+
+	command = mockCmd
+
+	err := s.Exec()
+	if err != nil {
+		t.Errorf("expected to error, got %q instead", err)
+	}
+}

--- a/internal/web_search/search_linux.go
+++ b/internal/web_search/search_linux.go
@@ -1,0 +1,39 @@
+package web_search
+
+import (
+	"bytes"
+	"os/exec"
+	"regexp"
+)
+
+var command = exec.Command
+
+var isWSLRelease = func(release string) bool {
+	matched, _ := regexp.Match(`.*microsoft.*`, []byte(release))
+	return matched
+}
+
+func (s *Search) Exec() error {
+	cmd := command("xdg-open", s.engine.URL())
+
+	release, err := kernelRelease()
+	if err != nil {
+		return err
+	}
+
+	if isWSLRelease(release) {
+		cmd = command("cmd.exe", "/c", "start", s.engine.URL())
+	}
+
+	return cmd.Run()
+}
+
+func kernelRelease() (string, error) {
+	var out bytes.Buffer
+
+	cmd := exec.Command("uname", "-r")
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	return out.String(), err
+}

--- a/internal/web_search/search_linux_test.go
+++ b/internal/web_search/search_linux_test.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package web_search
+
+import (
+	"testing"
+)
+
+func TestExecLinux(t *testing.T) {
+	e := NewGoogleEngine()
+	s := New(e)
+
+	mockIsWSLRelease = "f"
+	isWSLRelease = func(r string) bool {
+		return false
+	}
+
+	command = mockCmd
+
+	err := s.Exec()
+	if err != nil {
+		t.Errorf("expected no error, got %q instead", err)
+	}
+}
+
+func TestExecLinuxWSL(t *testing.T) {
+	e := NewGoogleEngine()
+	s := New(e)
+
+	mockIsWSLRelease = "t"
+	isWSLRelease = func(r string) bool {
+		return true
+	}
+
+	command = mockCmd
+
+	err := s.Exec()
+	if err != nil {
+		t.Errorf("expected no error, got %q instead", err)
+	}
+}

--- a/internal/web_search/search_test.go
+++ b/internal/web_search/search_test.go
@@ -1,0 +1,56 @@
+package web_search
+
+import (
+	"os"
+	"os/exec"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+var mockIsWSLRelease = "f"
+
+func TestExecCommandHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	cmdName := ""
+
+	switch runtime.GOOS {
+	case "linux":
+		cmdName = "xdg-open"
+
+		v, err := strconv.ParseBool(os.Getenv("GO_WANT_WSL_KERNEL_RELEASE"))
+		if err != nil {
+			v = false
+		}
+
+		if v {
+			cmdName = "cmd.exe"
+		}
+	case "darwin":
+		cmdName = "open"
+	}
+
+	if strings.Contains(os.Args[2], cmdName) {
+		os.Exit(0)
+	}
+
+	os.Exit(1)
+}
+
+func mockCmd(exe string, args ...string) *exec.Cmd {
+	cs := []string{"-test.run=TestExecCommandHelper"}
+	cs = append(cs, exe)
+	cs = append(cs, args...)
+
+	cmd := exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{
+		"GO_WANT_HELPER_PROCESS=1",
+		"GO_WANT_WSL_KERNEL_RELEASE=" + mockIsWSLRelease,
+	}
+
+	return cmd
+}

--- a/internal/web_search/stackoverflow.go
+++ b/internal/web_search/stackoverflow.go
@@ -1,0 +1,19 @@
+package web_search
+
+import "net/url"
+
+type stackoverflow struct {
+	engine
+}
+
+func NewStackOverflowEngine() Engine {
+	return &stackoverflow{
+		engine: engine{
+			url: &url.URL{
+				Scheme: "https",
+				Host:   "stackoverflow.com",
+				Path:   "search",
+			},
+		},
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,0 @@
-package main
-
-import "testing"
-
-func TestHelloWorld(t *testing.T) {
-	// t.Fatal("not implemented")
-}


### PR DESCRIPTION
command line to open browser with search term.

supports: google, github, stackoverflow, duckdukco

ex:
`web-search -engine=duckduckgo golang`